### PR TITLE
Add timeline parsing service and frontend integration

### DIFF
--- a/backend/Controllers/TimelineController.cs
+++ b/backend/Controllers/TimelineController.cs
@@ -1,0 +1,28 @@
+using Backend.Services.Timeline;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Backend.Controllers;
+
+[ApiController]
+[Route("timeline")]
+public class TimelineController : ControllerBase
+{
+    private readonly TimelineService _service;
+    public TimelineController(TimelineService service) => _service = service;
+
+    [HttpPost]
+    public IActionResult Post(IFormFile file)
+    {
+        if (file == null || file.Length == 0)
+            return BadRequest("No file uploaded");
+        using var stream = file.OpenReadStream();
+        var events = _service.ExtractEvents(stream, file.FileName).ToList();
+        var png = _service.RenderTimeline(events);
+        var payload = new
+        {
+            image = Convert.ToBase64String(png),
+            events = events.Select(e => new { date = e.Date.ToString("yyyy-MM-dd"), e.Description })
+        };
+        return Ok(payload);
+    }
+}

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Backend.Services.Timeline;
+
+var builder = WebApplication.CreateBuilder(args);
+builder.Services.AddControllers();
+builder.Services.AddSingleton<TimelineService>();
+
+var app = builder.Build();
+app.MapControllers();
+app.Run();

--- a/backend/Services/Timeline/TimelineService.cs
+++ b/backend/Services/Timeline/TimelineService.cs
@@ -1,0 +1,80 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+using Microsoft.Recognizers.Text.DateTime;
+using UglyToad.PdfPig;
+using SkiaSharp;
+
+namespace Backend.Services.Timeline;
+
+public record TimelineEvent(DateTime Date, string Description);
+
+public class TimelineService
+{
+    public IEnumerable<TimelineEvent> ExtractEvents(Stream fileStream, string fileName)
+    {
+        var ext = Path.GetExtension(fileName).ToLowerInvariant();
+        string text = ext switch
+        {
+            ".docx" => ExtractTextFromDocx(fileStream),
+            ".pdf" => ExtractTextFromPdf(fileStream),
+            _ => throw new NotSupportedException("Only DOCX and PDF supported")
+        };
+
+        var events = new List<TimelineEvent>();
+        var pattern = new Regex(@"\b(\d{4}-\d{2}-\d{2}|\d{2}/\d{2}/\d{4})\b");
+        foreach (var line in text.Split('\n'))
+        {
+            var match = pattern.Match(line);
+            if (match.Success && DateTime.TryParse(match.Value, out var date))
+            {
+                var description = line.Substring(match.Index + match.Length).Trim();
+                events.Add(new TimelineEvent(date, description));
+            }
+        }
+        return events.OrderBy(e => e.Date);
+    }
+
+    private string ExtractTextFromDocx(Stream stream)
+    {
+        using var doc = WordprocessingDocument.Open(stream, false);
+        var sb = new StringBuilder();
+        foreach (var text in doc.MainDocumentPart!.Document.Body!.Descendants<Text>())
+        {
+            sb.AppendLine(text.Text);
+        }
+        return sb.ToString();
+    }
+
+    private string ExtractTextFromPdf(Stream stream)
+    {
+        using var pdf = PdfDocument.Open(stream);
+        var sb = new StringBuilder();
+        foreach (var page in pdf.GetPages())
+        {
+            sb.AppendLine(page.Text);
+        }
+        return sb.ToString();
+    }
+
+    public byte[] RenderTimeline(IEnumerable<TimelineEvent> events)
+    {
+        const int width = 800;
+        int height = 100 + events.Count() * 40;
+        using var bitmap = new SKBitmap(width, height);
+        using var canvas = new SKCanvas(bitmap);
+        canvas.Clear(SKColors.White);
+        var paint = new SKPaint { Color = SKColors.Black, TextSize = 16 };
+        int y = 50;
+        foreach (var e in events)
+        {
+            canvas.DrawText(e.Date.ToString("yyyy-MM-dd"), 10, y, paint);
+            canvas.DrawText(e.Description, 150, y, paint);
+            y += 40;
+        }
+        using var image = SKImage.FromBitmap(bitmap);
+        using var data = image.Encode(SKEncodedImageFormat.Png, 100);
+        return data.ToArray();
+    }
+}

--- a/backend/TimelineApi.csproj
+++ b/backend/TimelineApi.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="DocumentFormat.OpenXml" Version="3.0.2" />
+    <PackageReference Include="UglyToad.PdfPig" Version="0.0.15" />
+    <PackageReference Include="Microsoft.Recognizers.Text.DateTime" Version="1.0.6" />
+    <PackageReference Include="SkiaSharp" Version="2.88.3" />
+  </ItemGroup>
+</Project>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Timeline</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
+    <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="./src/app.js"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "timeline-frontend",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "echo 'No tests'"
+  }
+}

--- a/frontend/src/app.js
+++ b/frontend/src/app.js
@@ -1,0 +1,40 @@
+const { useState } = React;
+
+function App() {
+  const [image, setImage] = useState(null);
+  const [events, setEvents] = useState([]);
+
+  const handleUpload = async (e) => {
+    e.preventDefault();
+    const file = e.target.elements.file.files[0];
+    if (!file) return;
+    const form = new FormData();
+    form.append('file', file);
+    const res = await fetch('/timeline', { method: 'POST', body: form });
+    const data = await res.json();
+    setImage('data:image/png;base64,' + data.image);
+    setEvents(data.events);
+  };
+
+  return (
+    React.createElement('div', null,
+      React.createElement('form', { onSubmit: handleUpload },
+        React.createElement('input', { type: 'file', name: 'file' }),
+        React.createElement('button', { type: 'submit' }, 'Upload')
+      ),
+      image && React.createElement('img', { src: image, alt: 'timeline' }),
+      React.createElement('table', null,
+        React.createElement('tbody', null,
+          events.map((e, i) =>
+            React.createElement('tr', { key: i },
+              React.createElement('td', null, e.date),
+              React.createElement('td', null, e.description)
+            )
+          )
+        )
+      )
+    )
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(React.createElement(App));


### PR DESCRIPTION
## Summary
- add TimelineService to parse DOCX/PDF, extract dated events, and render PNG timeline
- expose `/timeline` endpoint for uploading documents
- create minimal React UI to upload documents and display timeline image and event table

## Testing
- `dotnet test backend/TimelineApi.csproj` *(fails: command not found)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5ddc16e8c83239d96f8d247057980