### PR TITLE
Add build automation and backend logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,22 +1,7 @@
-### AL ###
-#Template for AL projects for Dynamics 365 Business Central
-#launch.json folder
-.vscode/
-#Cache folder
-.alcache/
-#Symbols folder
-.alpackages/
-#Snapshots folder
-.snapshots/
-#Testing Output folder
-.output/
-#Extension App-file
-*.app
-#Rapid Application Development File
-rad.json
-#Translation Base-file
-*.g.xlf
-#License-file
-*.flf
-#Test results file
-TestResults.xml
+build/
+legal-suite.tar.gz
+legal-suite.zip
+frontend/node_modules/
+frontend/dist/
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,0 +1,44 @@
+# Legal Suite
+
+## Running
+
+### Backend
+1. Install dependencies:
+   ```bash
+   pip install -r backend/requirements.txt
+   ```
+2. Start the API:
+   ```bash
+   uvicorn app:app --app-dir backend --reload
+   ```
+   The service logs requests and reports unhandled errors as 500 responses.
+
+### Frontend
+1. Change to the `frontend` directory:
+   ```bash
+   cd frontend
+   ```
+2. Install packages and build static assets:
+   ```bash
+   npm install
+   npm run build
+   ```
+   Built files are written to `frontend/dist`.
+
+## Development
+- Backend code lives in `backend/`. The FastAPI app provides request logging and basic error handling out of the box.
+- Frontend static assets live in `frontend/`. Update `index.html` and rebuild with `npm run build`.
+
+## Packaging
+The project ships with cross‑platform build scripts that assemble backend and frontend artifacts.
+
+- Unix/macOS:
+  ```bash
+  ./build.sh
+  ```
+- Windows:
+  ```powershell
+  pwsh build.ps1
+  ```
+
+The resulting archive (`legal-suite.tar.gz` on Unix or `legal-suite.zip` on Windows) contains the published backend, built frontend, and can be deployed as needed.

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,27 @@
+import logging
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+
+logging.basicConfig(level=logging.INFO,
+                    format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+logger = logging.getLogger("legal_suite")
+
+app = FastAPI()
+
+@app.middleware("http")
+async def log_requests(request: Request, call_next):
+    logger.info("%s %s", request.method, request.url.path)
+    try:
+        response = await call_next(request)
+    except Exception:
+        logger.exception("Unhandled exception")
+        return JSONResponse(status_code=500, content={"detail": "Internal Server Error"})
+    return response
+
+@app.get("/health")
+async def health():
+    return {"status": "ok"}
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,26 @@
+#!/usr/bin/env pwsh
+$ErrorActionPreference = 'Stop'
+$Root = Split-Path -Parent $MyInvocation.MyCommand.Path
+$Output = Join-Path $Root 'build'
+
+if (Test-Path $Output) { Remove-Item $Output -Recurse -Force }
+New-Item -ItemType Directory -Path $Output | Out-Null
+
+Write-Host 'Publishing backend'
+Push-Location (Join-Path $Root 'backend')
+pip install -r requirements.txt --target (Join-Path $Output 'backend') | Out-Null
+Copy-Item app.py (Join-Path $Output 'backend')
+Pop-Location
+
+Write-Host 'Building frontend'
+Push-Location (Join-Path $Root 'frontend')
+npm install | Out-Null
+npm run build | Out-Null
+Copy-Item 'dist' (Join-Path $Output 'frontend') -Recurse
+Pop-Location
+
+Write-Host 'Packaging'
+if (Test-Path (Join-Path $Root 'legal-suite.zip')) { Remove-Item (Join-Path $Root 'legal-suite.zip') }
+Compress-Archive -Path (Join-Path $Output '*') -DestinationPath (Join-Path $Root 'legal-suite.zip')
+
+Write-Host "Build complete: $(Join-Path $Root 'legal-suite.zip')"

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -e
+ROOT=$(cd "$(dirname "$0")" && pwd)
+OUTPUT="$ROOT/build"
+
+rm -rf "$OUTPUT"
+mkdir -p "$OUTPUT"
+
+echo "Publishing backend"
+pushd "$ROOT/backend" >/dev/null
+pip install -r requirements.txt --target "$OUTPUT/backend" >/dev/null
+cp app.py "$OUTPUT/backend/"
+popd >/dev/null
+
+echo "Building frontend"
+pushd "$ROOT/frontend" >/dev/null
+npm install >/dev/null
+npm run build >/dev/null
+cp -r dist "$OUTPUT/frontend"
+popd >/dev/null
+
+echo "Packaging"
+rm -f "$ROOT/legal-suite.tar.gz"
+tar -czf "$ROOT/legal-suite.tar.gz" -C "$OUTPUT" .
+
+echo "Build complete: $ROOT/legal-suite.tar.gz"

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Legal Suite</title>
+</head>
+<body>
+  <h1>Legal Suite Frontend</h1>
+</body>
+</html>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "legal-suite-frontend",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "legal-suite-frontend",
+      "version": "1.0.0"
+    }
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "legal-suite-frontend",
+  "version": "1.0.0",
+  "scripts": {
+    "build": "mkdir -p dist && cp index.html dist/index.html"
+  }
+}


### PR DESCRIPTION
## Summary
- add cross-platform build scripts for backend publish, frontend build, and packaging
- document running, development, and packaging steps
- introduce FastAPI service with request logging and error handling

## Testing
- `python -m py_compile backend/app.py`
- `./build.sh` *(fails: Could not find a version that satisfies the requirement fastapi)*
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5ddc568088323a10a9c4b359dacaf